### PR TITLE
use --no-warn-unused-cli on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,11 @@ macro(build_ignition_cmake2)
   set(IGNITION_CMAKE2_TARGET_VERSION "2.8.0")
 
   if(DEFINED CMAKE_BUILD_TYPE)
-    list(APPEND extra_cmake_args -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
+    list(APPEND extra_cmake_args "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
+    if (MSVC)
+      # ign-cmake2 ignores CMAKE_BUILD_TYPE on Windows, disable the warning until we know why
+      list(APPEND extra_cmake_args "--no-warn-unused-cli")
+    endif()
   endif()
 
   if(DEFINED CMAKE_TOOLCHAIN_FILE)


### PR DESCRIPTION
Alternative to #1 to fix the CMake warning on windows