### PR TITLE
Vendor gz_cmake2 unconditionally.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,7 @@ project(ignition_cmake2_vendor)
 find_package(ament_cmake_core REQUIRED)
 find_package(ament_cmake_vendor_package REQUIRED)
 
-find_package(ignition-cmake2 2.6.2 QUIET)
-
 ament_vendor(ignition_cmake2_vendor
-  SATISFIED ${ignition-cmake2_FOUND}
   VCS_URL https://github.com/ignitionrobotics/ign-cmake.git
   VCS_VERSION ignition-cmake2_2.14.0
   CMAKE_ARGS

--- a/package.xml
+++ b/package.xml
@@ -14,8 +14,6 @@
   <buildtool_depend>ament_cmake_test</buildtool_depend>
   <buildtool_depend>ament_cmake_vendor_package</buildtool_depend>
 
-  <depend>ignition-cmake2</depend>
-
   <test_depend>ament_cmake_copyright</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>
   <test_depend>ament_cmake_xmllint</test_depend>


### PR DESCRIPTION
On Ubuntu Noble, there is no usable upstream version of gz-cmake2 and we are in the process of updating all Gazebo packages to be directly vendorable. In the meantime, switch the current Gazebo vendor packages in ROS 2 core to vendor unconditionally.